### PR TITLE
Correct `periodic: bool` value in dataset metadata files`

### DIFF
--- a/covid_api/db/static/datasets/__init__.py
+++ b/covid_api/db/static/datasets/__init__.py
@@ -109,13 +109,10 @@ class DatasetManager(object):
             if not dataset.s3_location:
                 continue
 
-            domain_args: Dict[str, Any] = {"dataset_folder": dataset.s3_location}
-
-            if dataset.time_unit:
-                # if `time_unit` is present in the dataset metadata item, the
-                # dataset is considered to be periodic and only the start and
-                # end dates will be returned.
-                domain_args["time_unit"] = dataset.time_unit
+            domain_args: Dict[str, Any] = {
+                "dataset_folder": dataset.s3_location,
+                "is_periodic": dataset.is_periodic,
+            }
 
             if spotlight_id:
                 domain_args["spotlight_id"] = spotlight_id

--- a/covid_api/db/static/datasets/__init__.py
+++ b/covid_api/db/static/datasets/__init__.py
@@ -117,7 +117,7 @@ class DatasetManager(object):
             if spotlight_id:
                 domain_args["spotlight_id"] = spotlight_id
 
-            dataset.domain = get_dataset_domain(**(domain_args))
+            dataset.domain = get_dataset_domain(**domain_args)
 
         return datasets
 

--- a/covid_api/db/static/datasets/agriculture.json
+++ b/covid_api/db/static/datasets/agriculture.json
@@ -3,6 +3,7 @@
     "name": "Agriculture",
     "type": "raster-timeseries",
     "s3_location": "agriculture",
+    "time_unit": "day",
     "source": {
         "type": "raster",
         "tiles": [

--- a/covid_api/db/static/datasets/detections-ship.json
+++ b/covid_api/db/static/datasets/detections-ship.json
@@ -4,6 +4,8 @@
     "type": "inference-timeseries",
     "description": "Ships detected each day in PlanetScope imagery are shown in red.",
     "s3_location": "detections-ship",
+    "is_periodic": false,
+    "time_unit": "day",
     "source": {
         "type": "geojson",
         "tiles": [

--- a/covid_api/db/static/datasets/no2-diff.json
+++ b/covid_api/db/static/datasets/no2-diff.json
@@ -1,0 +1,45 @@
+{
+    "id": "no2-diff",
+    "name": "NO\u2082 (Diff)",
+    "type": "raster-timeseries",
+    "domain": [],
+    "time_unit": "month",
+    "s3_location": "OMNO2d_HRMDifference",
+    "source": {
+        "type": "raster",
+        "tiles": [
+            "${config.api}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/OMNO2d_HRMDifference/OMI_trno2_0.10x0.10_{date}_Col3_V4.nc.tif&resampling_method=bilinear&bidx=1&rescale=-8000000000000000%2C8000000000000000&color_map=rdbu_r&color_formula=gamma r {gamma}"
+        ]
+    },
+    "exclusiveWith": [
+        "co2",
+        "co2-diff",
+        "gibs-population",
+        "car-count",
+        "nightlights-viirs",
+        "nightlights-hd",
+        "detection-ship",
+        "detection-multi",
+        "water-chlorophyll",
+        "water-spm",
+        "no2"
+    ],
+    "enabled": false,
+    "swatch": {
+        "color": "#f2a73a",
+        "name": "Gold"
+    },
+    "legend": {
+        "type": "gradient-adjustable",
+        "min": "less",
+        "max": "more",
+        "stops": [
+            "#3A88BD",
+            "#C9E0ED",
+            "#E4EEF3",
+            "#FDDCC9",
+            "#DD7059"
+        ]
+    },
+    "info": "This layer shows changes in nitrogen dioxide (NO₂) levels. Redder colors indicate increases in NO₂. Bluer colors indicate lower levels of NO₂."
+}

--- a/covid_api/db/static/datasets/water-chlorophyll.json
+++ b/covid_api/db/static/datasets/water-chlorophyll.json
@@ -4,6 +4,7 @@
     "type": "raster-timeseries",
     "description": "Chlorophyll is an indicator of algae growth. Redder colors indicate increases in chlorophyll-a and worse water quality. Bluer colors indicate decreases in chlorophyll-a and improved water quality. White areas indicate no change.",
     "time_unit": "day",
+    "is_periodic": false,
     "s3_location": "oc3_chla_anomaly",
     "source": {
         "type": "raster",

--- a/covid_api/db/static/datasets/water-spm.json
+++ b/covid_api/db/static/datasets/water-spm.json
@@ -5,6 +5,7 @@
     "description": "Turbidity refers to the amount of sediment or particles suspended in water. Darker colors indicate more sediment and murkier water. Lighter colors indicate less sediment and clearer water.",
     "time_unit": "day",
     "s3_location": "spm_anomaly",
+    "is_periodic": false,
     "source": {
         "type": "raster",
         "tiles": [

--- a/covid_api/db/utils.py
+++ b/covid_api/db/utils.py
@@ -78,7 +78,7 @@ def get_dataset_folders_by_spotlight(spotlight_id: str) -> Set[str]:
 
 
 def get_dataset_domain(
-    dataset_folder: str, time_unit: str = None, spotlight_id: str = None,
+    dataset_folder: str, is_periodic: bool, spotlight_id: str = None,
 ):
     """
     Returns a domain for a given dataset as identified by a folder. If a
@@ -132,7 +132,7 @@ def get_dataset_domain(
 
         dates.append(date)
 
-    if time_unit and len(dates):
+    if is_periodic and len(dates):
         return [min(dates), max(dates)]
 
     return dates

--- a/covid_api/db/utils.py
+++ b/covid_api/db/utils.py
@@ -135,7 +135,7 @@ def get_dataset_domain(
     if is_periodic and len(dates):
         return [min(dates), max(dates)]
 
-    return dates
+    return sorted(dates)
 
 
 def s3_get(bucket: str, key: str):

--- a/covid_api/models/static.py
+++ b/covid_api/models/static.py
@@ -38,6 +38,7 @@ class Dataset(BaseModel):
     description: str = ""
     type: str
     s3_location: Optional[str]
+    is_periodic: bool = True
     time_unit: Optional[str]
     domain: List = []
     source: Source
@@ -54,6 +55,7 @@ class OutputDataset(BaseModel):
     name: str
     description: str = ""
     type: str
+    is_periodic: bool = True
     time_unit: Optional[str]
     domain: List = []
     source: Source

--- a/tests/routes/v1/test_datasets.py
+++ b/tests/routes/v1/test_datasets.py
@@ -117,7 +117,7 @@ def test_detections_datasets(app):
     assert "datasets" in content
 
     dataset_info = [d for d in content["datasets"] if d["id"] == "detections-plane"][0]
-    assert len(dataset_info["domain"]) > 2
+    assert len(dataset_info["domain"]) == 2
 
 
 @mock_s3
@@ -134,10 +134,11 @@ def test_datasets_daily(app):
     assert "datasets" in content
 
     dataset_info = [d for d in content["datasets"] if d["id"] == "water-chlorophyll"][0]
+    assert len(dataset_info["domain"]) > 2
     assert dataset_info["domain"][0] == datetime.strftime(
         datetime(2020, 1, 29), "%Y-%m-%dT%H:%M:%S"
     )
-    assert dataset_info["domain"][1] == datetime.strftime(
+    assert dataset_info["domain"][-1] == datetime.strftime(
         datetime(2020, 3, 2), "%Y-%m-%dT%H:%M:%S"
     )
 


### PR DESCRIPTION
This PR adds a `periodic:bool = True` value to the Dataset model and `"periodic": false` key to the following manifest files: 
- `detections-ship.json`
- `water-spm.json`
- `water-cholorphyll.json`

### Validation Testing: 
The only difference I've found between the `/datasets` endpoint values (see below) and the `layers/index.js` file in the front-end is: 
- `water-cholorphyll` is listed as a dataset for the `tk` spotlight in the `/datasets` endpoing, but not in the `layers/index.js` file
- `index.js` considers that all global datasets are also spotlight datasets whereas `/datasets` endpoint does not (ie: `datasets/tk` does NOT return `co2` and `co2-diff`). Is this the desired behaviour? 

### `/datasets` endpoint values:
```
GET /datasets/global -->
- population: domain [ ]
- agriculture: domain [2018-03-06T00:00:00 , 2020-06-28T00:00:00 (periodic)
- co2: domain [2020-01-01T00:00:00 , 2020-05-17T00:00:00 (periodic)
- no2-diff: domain [2015-01-01T00:00:00 , 2020-07-01T00:00:00 (periodic)
- co2-diff: domain [2020-01-01T00:00:00 , 2020-05-17T00:00:00 (periodic)
- no2: domain [2004-10-01T00:00:00 , 2020-07-01T00:00:00 (periodic)

GET /datasets/be -->
- nightlights-hd: domain [2020-01-01T00:00:00 , 2020-07-01T00:00:00 (periodic)
- nightlights-viirs: domain [2020-01-01T00:00:00 , 2020-07-08T00:00:00 (periodic)
- detections-plane: domain [2020-01-09T00:00:00 , 2020-05-19T00:00:00 (periodic)

GET /datasets/du -->
- nightlights-hd: domain [2020-01-01T00:00:00 , 2020-07-01T00:00:00 (periodic)
- nightlights-viirs: domain [2020-01-01T00:00:00 , 2020-07-08T00:00:00 (periodic)

GET /datasets/gh -->
- nightlights-hd: domain [2020-01-01T00:00:00 , 2020-07-01T00:00:00 (periodic)
- nightlights-viirs: domain [2020-01-01T00:00:00 , 2020-07-08T00:00:00 (periodic)

GET /datasets/la -->
- nightlights-hd: domain [2020-01-01T00:00:00 , 2020-07-01T00:00:00 (periodic)
- nightlights-viirs: domain [2020-01-01T00:00:00 , 2020-07-08T00:00:00 (periodic)
- detections-plane: domain [2020-01-09T00:00:00 , 2020-05-19T00:00:00 (periodic)
- detections-ship: domain [2020-01-22T00:00:00 , ..., 2020-04-24T00:00:00 (NON periodic)

GET /datasets/sf -->
- water-spm: domain [2020-03-02T00:00:00 , ..., 2020-07-03T00:00:00 (NON periodic)
- nightlights-hd: domain [2020-01-01T00:00:00 , 2020-07-01T00:00:00 (periodic)
- nightlights-viirs: domain [2020-01-01T00:00:00 , 2020-07-08T00:00:00 (periodic)
- water-chlorophyll: domain [2020-03-02T00:00:00 , ..., 2020-07-13T00:00:00 (NON periodic)
- detections-plane: domain [2020-01-10T00:00:00 , 2020-05-19T00:00:00 (periodic)
- detections-ship: domain [2020-01-22T00:00:00 , ..., 2020-04-21T00:00:00 (NON periodic)

GET /datasets/tk -->
- nightlights-hd: domain [2020-01-01T00:00:00 , 2020-07-01T00:00:00 (periodic)
- nightlights-viirs: domain [2020-01-01T00:00:00 , 2020-07-08T00:00:00 (periodic)
- water-chlorophyll: domain [2018-01-03T00:00:00 , ..., 2020-07-25T00:00:00 (NON periodic)
- detections-plane: domain [2020-01-09T00:00:00 , 2020-05-17T00:00:00 (periodic)

GET /datasets/ny -->
- water-spm: domain [2020-01-01T00:00:00 , ..., 2020-08-05T00:00:00 (NON periodic)
- nightlights-hd: domain [2020-01-01T00:00:00 , 2020-07-01T00:00:00 (periodic)
- nightlights-viirs: domain [2020-01-01T00:00:00 , 2020-07-08T00:00:00 (periodic)
- water-chlorophyll: domain [2020-01-01T00:00:00 , ..., 2020-08-05T00:00:00 (NON periodic)
- detections-plane: domain [2020-01-09T00:00:00 , 2020-05-19T00:00:00 (periodic)
- detections-ship: domain [2020-01-20T00:00:00 , ..., 2020-03-27T00:00:00 (NON periodic)
```


