### PR TITLE
properly calculate weighted median

### DIFF
--- a/covid_api/api/utils.py
+++ b/covid_api/api/utils.py
@@ -222,11 +222,12 @@ def get_zonal_stat(geojson: Feature, raster: str) -> Tuple[float, float]:
         window_affine = src.window_transform(window)
         data = src.read(window=window)
 
+        # calculate the coverage of pixels for weighting
         pctcover = rasterize_pctcover(geom, atrans=window_affine, shape=data.shape[1:])
 
         return (
-            np.nanmean(data * pctcover),
-            np.nanmedian(data * pctcover),
+            np.average(data[0], weights=pctcover),
+            np.nanmedian(data),
         )
 
 


### PR DESCRIPTION
Properly calculates a pixel-coverage weighted mean, median uses all values equally cc: @olafveerman 

re: https://github.com/NASA-IMPACT/covid-dashboard/issues/412