### PR TITLE
Remove gamma from tile url for NO2 diff

### DIFF
--- a/covid_api/db/static/datasets/no2-diff.json
+++ b/covid_api/db/static/datasets/no2-diff.json
@@ -8,7 +8,7 @@
     "source": {
         "type": "raster",
         "tiles": [
-            "{api_url}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/OMNO2d_HRMDifference/OMI_trno2_0.10x0.10_{date}_Col3_V4.nc.tif&resampling_method=bilinear&bidx=1&rescale=-8000000000000000%2C8000000000000000&color_map=rdbu_r&color_formula=gamma r {gamma}"
+            "{api_url}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/OMNO2d_HRMDifference/OMI_trno2_0.10x0.10_{date}_Col3_V4.nc.tif&resampling_method=bilinear&bidx=1&rescale=-8000000000000000%2C8000000000000000&color_map=rdbu_r"
         ]
     },
     "exclusive_with": [


### PR DESCRIPTION
Gamma is not supported in combination with legend type 'gradient'. This functionality also doesn't yet make sense for difference maps. Fix nasa-impact/covid-dashboard#450