### PR TITLE
Add `detections-vehicles` dataset to backend

### DIFF
--- a/covid_api/api/api_v1/endpoints/detections.py
+++ b/covid_api/api/api_v1/endpoints/detections.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, HTTPException
 router = APIRouter()
 
 # TODO: unhardcoded types and dates
-MLTypes = Enum("MLTypes", [(ml, ml) for ml in ["ship", "multiple", "plane"]])  # type: ignore
+MLTypes = Enum("MLTypes", [(ml, ml) for ml in ["ship", "multiple", "plane", "vehicles"]])  # type: ignore
 
 
 @router.get(

--- a/covid_api/api/utils.py
+++ b/covid_api/api/utils.py
@@ -729,8 +729,16 @@ def site_date_to_scenes(site: str, date: str):
     )
     ship_site_date_lines = ship_site_date_to_scenes_csv.decode("utf-8").split("\n")
 
+    vehicles_site_date_to_scenes_csv = s3_get(
+        INDICATOR_BUCKET, "detections-vehicles/detection_scenes.csv"
+    )
+    vehicles_site_date_lines = vehicles_site_date_to_scenes_csv.decode("utf-8").split(
+        "\n"
+    )
+
     reader = list(csv.DictReader(plane_site_date_lines))
     reader.extend(list(csv.DictReader(ship_site_date_lines)))
+    reader.extend(list(csv.DictReader(vehicles_site_date_lines)))
 
     site_date_to_scenes_dict: dict = {}
 

--- a/covid_api/api/utils.py
+++ b/covid_api/api/utils.py
@@ -729,16 +729,8 @@ def site_date_to_scenes(site: str, date: str):
     )
     ship_site_date_lines = ship_site_date_to_scenes_csv.decode("utf-8").split("\n")
 
-    vehicles_site_date_to_scenes_csv = s3_get(
-        INDICATOR_BUCKET, "detections-vehicles/detection_scenes.csv"
-    )
-    vehicles_site_date_lines = vehicles_site_date_to_scenes_csv.decode("utf-8").split(
-        "\n"
-    )
-
     reader = list(csv.DictReader(plane_site_date_lines))
     reader.extend(list(csv.DictReader(ship_site_date_lines)))
-    reader.extend(list(csv.DictReader(vehicles_site_date_lines)))
 
     site_date_to_scenes_dict: dict = {}
 
@@ -748,4 +740,6 @@ def site_date_to_scenes(site: str, date: str):
             json.loads(row["scene_id"].replace("'", '"'))
         )
 
-    return site_date_to_scenes_dict[f"{site}-{date}"]
+    # deduplicate scene list (in case multiple datasets contains the same
+    # scene id)
+    return list(set(site_date_to_scenes_dict[f"{site}-{date}"]))

--- a/covid_api/db/static/datasets/__init__.py
+++ b/covid_api/db/static/datasets/__init__.py
@@ -133,7 +133,11 @@ class DatasetManager(object):
                     tile.replace("{api_url}", api_url)
                     for tile in dataset.compare.source.tiles
                 ]
-            if dataset.id in ["detections-ship", "detections-plane"]:
+            if dataset.id in [
+                "detections-ship",
+                "detections-plane",
+                "detections-vehicles",
+            ]:
                 dataset.source = GeoJsonSource(
                     type=dataset.source.type, data=dataset.source.tiles[0]
                 )

--- a/covid_api/db/static/datasets/agriculture.json
+++ b/covid_api/db/static/datasets/agriculture.json
@@ -24,7 +24,8 @@
         "water-chlorophyll",
         "water-spm",
         "detections-ship",
-        "detections-plane"
+        "detections-plane",
+        "detections-vehicles"
     ],
     "enabled": false,
     "swatch": {

--- a/covid_api/db/static/datasets/co2-diff.json
+++ b/covid_api/db/static/datasets/co2-diff.json
@@ -24,7 +24,8 @@
         "water-chlorophyll",
         "water-spm",
         "detections-ship",
-        "detections-plane"
+        "detections-plane",
+        "detections-vehicles"
     ],
     "enabled": false,
     "swatch": {

--- a/covid_api/db/static/datasets/co2.json
+++ b/covid_api/db/static/datasets/co2.json
@@ -23,7 +23,8 @@
         "water-chlorophyll",
         "water-spm",
         "detections-ship",
-        "detections-plane"
+        "detections-plane",
+        "detections-vehicles"
     ],
     "enabled": false,
     "compare": {

--- a/covid_api/db/static/datasets/detections-plane.json
+++ b/covid_api/db/static/datasets/detections-plane.json
@@ -29,7 +29,8 @@
         "detection-multi",
         "water-chlorophyll",
         "water-spm",
-        "detections-ship"
+        "detections-ship",
+        "detections-vehicles"
     ],
     "enabled": false,
     "swatch": {

--- a/covid_api/db/static/datasets/detections-plane.json
+++ b/covid_api/db/static/datasets/detections-plane.json
@@ -8,7 +8,7 @@
     "source": {
         "type": "geojson",
         "tiles": [
-            "{api_url}/detections/plane/{spotlightId}/{date}.geojson"
+            "{api_url}/detections-plane/{spotlightId}/{date}.geojson"
         ]
     },
     "background_source": {

--- a/covid_api/db/static/datasets/detections-ship.json
+++ b/covid_api/db/static/datasets/detections-ship.json
@@ -8,7 +8,7 @@
     "source": {
         "type": "geojson",
         "tiles": [
-            "{api_url}/detections/ship/{spotlightId}/{date}.geojson"
+            "{api_url}/detections-ship/{spotlightId}/{date}.geojson"
         ]
     },
     "background_source": {

--- a/covid_api/db/static/datasets/detections-vehicles.json
+++ b/covid_api/db/static/datasets/detections-vehicles.json
@@ -8,13 +8,13 @@
     "source": {
         "type": "geojson",
         "tiles": [
-            "{api_url}/detections/vehicles/{spotlightId}/{date}.geojson"
+            "{api_url}/detections-vehicles/{spotlightId}/{date}.geojson"
         ]
     },
     "background_source": {
         "type": "raster",
         "tiles": [
-            "{api_url}/planet/{z}/{x}/{y}?date={date}&site={spotlightId}"
+            "{api_url}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/detections-vehicles/background/{spotlightId}/{date}.tif"
         ]
     },
     "exclusive_with": [

--- a/covid_api/db/static/datasets/detections-vehicles.json
+++ b/covid_api/db/static/datasets/detections-vehicles.json
@@ -1,14 +1,14 @@
 {
-    "id": "detections-ship",
-    "name": "Shipping",
+    "id": "detections-vehicles",
+    "name": "Vehicle",
     "type": "inference-timeseries",
-    "s3_location": "detections-ship",
+    "s3_location": "detections-vehicles",
     "is_periodic": false,
     "time_unit": "day",
     "source": {
         "type": "geojson",
         "tiles": [
-            "{api_url}/detections/ship/{spotlightId}/{date}.geojson"
+            "{api_url}/detections/vehicles/{spotlightId}/{date}.geojson"
         ]
     },
     "background_source": {
@@ -29,13 +29,13 @@
         "detection-multi",
         "water-chlorophyll",
         "water-spm",
-        "detections-plane",
-        "detections-vehicles"
+        "detections-ship",
+        "detections-plane"
     ],
     "enabled": false,
     "swatch": {
         "color": "#C0C0C0",
         "name": "Grey"
     },
-    "info": "Ships detected each day in PlanetScope imagery are shown in red."
+    "info": "Vehicles detected each day in PlanetScope imagery are shown in red."
 }

--- a/covid_api/db/static/datasets/nightlights-hd.json
+++ b/covid_api/db/static/datasets/nightlights-hd.json
@@ -23,7 +23,8 @@
         "water-chlorophyll",
         "water-spm",
         "detections-ship",
-        "detections-plane"
+        "detections-plane",
+        "detections-vehicles"
     ],
     "swatch": {
         "color": "#C0C0C0",

--- a/covid_api/db/static/datasets/nightlights-viirs.json
+++ b/covid_api/db/static/datasets/nightlights-viirs.json
@@ -23,7 +23,8 @@
         "water-chlorophyll",
         "water-spm",
         "detections-ship",
-        "detections-plane"
+        "detections-plane",
+        "detections-vehicles"
     ],
     "swatch": {
         "color": "#C0C0C0",

--- a/covid_api/db/static/datasets/no2.json
+++ b/covid_api/db/static/datasets/no2.json
@@ -23,7 +23,8 @@
     "water-chlorophyll",
     "water-spm",
     "detections-ship",
-    "detections-plane"
+    "detections-plane",
+    "detections-vehicles"
   ],
   "enabled": true,
   "compare": {

--- a/covid_api/db/static/datasets/water-chlorophyll.json
+++ b/covid_api/db/static/datasets/water-chlorophyll.json
@@ -23,7 +23,8 @@
         "detection-multi",
         "water-spm",
         "detections-ship",
-        "detections-plane"
+        "detections-plane",
+        "detections-vehicles"
     ],
     "swatch": {
         "color": "#154F8D",

--- a/covid_api/db/static/datasets/water-spm.json
+++ b/covid_api/db/static/datasets/water-spm.json
@@ -23,7 +23,8 @@
         "detection-multi",
         "water-chlorophyll",
         "detections-ship",
-        "detections-plane"
+        "detections-plane",
+        "detections-vehicles"
     ],
     "swatch": {
         "color": "#154F8D",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ extra_reqs = {
 
 setup(
     name="covid_api",
-    version="0.3.0",
+    version="0.3.1",
     description=u"",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
### What I did: 
Added `detections-vehicles` dataset - addresses [covid-dashboard issue #440](https://github.com/NASA-IMPACT/covid-dashboard/issues/440)

### How I did it: 
Extracted scene_ids for each feature in the two geojsons currently in S3 and built + uploaded a `detections_scenes.csv` file. 

Created a new dataset metadata file called `detections-vehicles.json` which is very similar to `detection-plane.json` and `detections-ship.json`.

Added `detections-vehicle` to all datasets which has `detections-ship` and `detection-plane` as exclusive datasets

### How you can test it: 
Run `docker-compose up --build` 

- Hit `http://localhost:8000/v1/datasets` notice a new dataset for `detections-vehicles` is present (with `{spotlightId}` in url, since no spotlight has been specified)
- Hit `http://localhost:8000/v1/datasets/la` notice that the `detections-vehicles` is still present
- Hist `http://localhost:8000/v1/datasets/ny` notices that the `detections-vehicles` is no longer present

@olafveerman @drewbo would love some feedback on the `detections-vehicles.json` metadata files (I copy-pasted the description from `detections-ships.json`, not sure if the `info` field is missing anything)

@danielfdsilva tagging you because the format of the geojsons in s3 seems different from the other `detection-*` datasets. Let me know if you need anything in order to implement in the front end

@lillythomas fyi


