### PR TITLE
Use correct opacity property

### DIFF
--- a/covid_api/db/static/datasets/no2-diff.json
+++ b/covid_api/db/static/datasets/no2-diff.json
@@ -11,6 +11,9 @@
             "{api_url}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/OMNO2d_HRMDifference/OMI_trno2_0.10x0.10_{date}_Col3_V4.nc.tif&resampling_method=bilinear&bidx=1&rescale=-8000000000000000%2C8000000000000000&color_map=rdbu_r"
         ]
     },
+    "paint": {
+        "raster-opacity": 0.9
+    },
     "exclusive_with": [
         "co2",
         "co2-diff",

--- a/covid_api/db/static/datasets/no2.json
+++ b/covid_api/db/static/datasets/no2.json
@@ -11,6 +11,9 @@
       "{api_url}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/OMNO2d_HRM/OMI_trno2_0.10x0.10_{date}_Col3_V4.nc.tif&resampling_method=bilinear&bidx=1&rescale=0%2C1.5e16&color_map=custom_no2&color_formula=gamma r {gamma}"
     ]
   },
+  "paint": {
+      "raster-opacity": 0.9
+  },
   "exclusive_with": [
     "agriculture",
     "co2",

--- a/covid_api/db/static/datasets/recovery.json
+++ b/covid_api/db/static/datasets/recovery.json
@@ -11,7 +11,7 @@
         ]
     },
     "paint": {
-        "raster_opacity": 0.9
+        "raster-opacity": 0.9
     },
     "exclusiveWith": [
         "agriculture",

--- a/covid_api/db/static/datasets/slowdown.json
+++ b/covid_api/db/static/datasets/slowdown.json
@@ -10,7 +10,7 @@
         ]
     },
     "paint": {
-        "raster_opacity": 0.9
+        "raster-opacity": 0.9
     },
     "exclusiveWith": [
         "agriculture",

--- a/covid_api/models/static.py
+++ b/covid_api/models/static.py
@@ -69,10 +69,21 @@ class DatasetComparison(BaseModel):
     time_unit: Optional[str]
 
 
+def snake_case_to_kebab_case(s):
+    """Util method to convert kebab-case fieldnames to snake_case."""
+    return s.replace("_", "-")
+
+
 class Paint(BaseModel):
     """Paint Model."""
 
     raster_opacity: int
+
+    class Config:
+        """Paint Model Config"""
+
+        alias_generator = snake_case_to_kebab_case
+        allow_population_by_field_name = True
 
 
 class Dataset(BaseModel):


### PR DESCRIPTION
`raster_opacity` is not Mapbox paint property. We should use `raster-opacity` instead.

Fix nasa-impact/covid-dashboard#482