### PR TITLE
Implemented autoreload on code changes in dockerfile

### DIFF
--- a/Dockerfiles/ecs/Dockerfile
+++ b/Dockerfiles/ecs/Dockerfile
@@ -10,3 +10,4 @@ COPY covid_api/ /app/covid_api/
 COPY setup.py /app/setup.py
 
 RUN pip install -e /app/. --no-cache-dir
+CMD ["/start-reload.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,10 @@ services:
       dockerfile: Dockerfiles/ecs/Dockerfile
     ports:
       - "8000:8000"
+    volumes:
+      - type: bind
+        source: ./covid_api
+        target: /app/covid_api
     environment:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
### What I'm changing: 

Stopping and re-starting the API docker container every time I wanted to test some changes was becoming time consuming, so I implement autoreloading on file changes. 

### How I did it: 
I added `CMD ["/start-reload.sh"]` to the `/ecs/Dockerfile` and mounted the `covid_api/` code directory in the docker container (in `docker-compose.yml`)

### How you can test it: 
Run `docker-compose up --build` and wait for the API to get up and running. 

Make a small code modification in the API files (eg: add a print statement to the `/datasets` LIST endpoint) and verify that the API reloads: 
![image](https://user-images.githubusercontent.com/11858457/100914195-b91c8d80-34a0-11eb-8582-9cf0ca47c514.png)

### Notes: 
Was there a reason this was not enabled initially? I want to be sure this won't cause any issues with the production deployments of the API. @drewbo @olafveerman ? 
