### PR TITLE
Explicitly set docker-compose version to 3.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.2'
 
 services:
   api:


### PR DESCRIPTION
Following the instructions in the Readme, I ran into an issue with the Docker Compose file:

```
$ docker-compose up --build
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.api.volumes contains an invalid type, it should be a string
```

Turns out that the long syntax on the volumes is [only supported from 3.2 onward](https://docs.docker.com/compose/compose-file/compose-versioning/#version-32). This PR explicitly sets the compose version to 3.2.