### PR TITLE
Updated circleCI config to deploy to staging on pushes to develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           name: run pre-commit
           command: ~/.local/bin/pre-commit run --all-files
 
-  deploy:
+  deploy-staging:
     docker:
       - image: nikolaik/python-nodejs:python3.7-nodejs12
     working_directory: ~/covid-api
@@ -42,16 +42,39 @@ jobs:
             apt-get update
             apt-get install docker-ce-cli -y
 
-      - run:
-          name: create lambda package
+      - deploy:
+          name: develop branch deployed to staging cdk stack
           command: |
-            docker build . -t lambda:latest -f Dockerfiles/lambda/Dockerfile
-            docker run --name lambda lambda:latest echo "container up"
-            docker cp lambda:/tmp/package.zip package.zip
-            docker stop lambda
+            if [ "${CIRCLE_BRANCH}" == "develop" ]; then
+              STAGE='staging' cdk deploy covid-api-lambda-staging --region us-east-1 --require-approval never
+            fi
+
+  deploy-production:
+    docker:
+      - image: nikolaik/python-nodejs:python3.7-nodejs12
+    working_directory: ~/covid-api
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: install dependencies
+          command: |
+            pip install -e .["deploy"] --user
+            npm install -g cdk
+
+      - run:
+          name: install docker-ce-cli
+          command: |
+            apt-get update
+            apt-get install apt-transport-https \
+              ca-certificates curl gnupg2 software-properties-common -y
+            curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+            add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian buster stable"
+            apt-get update
+            apt-get install docker-ce-cli -y
 
       - deploy:
-          name: master branch deployed to cdk stack
+          name: master branch deployed to production cdk stack
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               STAGE='prod' cdk deploy covid-api-lambda-prod --region us-east-1 --require-approval never
@@ -62,7 +85,13 @@ workflows:
   test_and_deploy:
     jobs:
       - test
-      - deploy:
+      - deploy-staging: 
+          requires:
+            - test
+          filters:
+            branches:
+              only: develop
+      - deploy-production:
           requires:
             - test
           filters:


### PR DESCRIPTION
# What I did:
Implemented an automatic deployment to a CDK stack called `staging` from all pushes to the `develop` branch. This will give us a testing backend environment, which will come in handy when trying share backend work with external partners before pushing to production, such as validating new datasets, for example. 

I also removed the lambda package creation steps from the CircleCI config since that is now handled within the CDK deployment script

# How I did it: 
I moved the `deploy` job to `deploy-production` and created anther job `deploy-staging` which filters for the branch named `develop`. 

I also removed the `create lambda package` step of the `deploy` job. 

# How you can test it: 
Merge a small PR to develop and verify that the CDK staging stack gets updates (will update this PR with a comment containing the STACK URL once it get's deployed). 

