### PR TITLE
Load Planet API key from environment variable

### DIFF
--- a/stack/app.py
+++ b/stack/app.py
@@ -99,6 +99,7 @@ class covidApiLambdaStack(core.Stack):
                 LOG_LEVEL="error",
                 MEMCACHE_HOST=cache.attr_configuration_endpoint_address,
                 MEMCACHE_PORT=cache.attr_configuration_endpoint_port,
+                PLANET_API_KEY=os.environ["PLANET_API_KEY"],
             )
         )
 


### PR DESCRIPTION
# What I did: 
Load Planet API key from environment variable (in circleCI deployment).

I couldn't find any references to `PLANET_API_KEY` in any of the deployment functionality (in CircleCI, `stack/app.py`, etc). Given that the API key was present in the production lambda, but not the staging one I deployed last week, I assume the key was added manually. 

# How I did it: 
Added the Planet API key (`9***b110e3`) to the CircleCI project environment variables alongside the aws keys

# How you can test it: 
Merge this branch to develop, verify that the lambda function get's updated with the correct API key.


