### PR TITLE
Fix incorrect nighlights-viirs source URL for `du` and `gh` 

### DIFF
--- a/covid_api/db/static/datasets/__init__.py
+++ b/covid_api/db/static/datasets/__init__.py
@@ -168,6 +168,8 @@ class DatasetManager(object):
             # spotlight id (if a spotlight was requested)
             format_url_params = dict(api_url=api_url)
             if spotlight_id:
+                if k == "nightlights-hd" and spotlight_id in ["du", "gh"]:
+                    spotlight_id = "EUPorts"
                 format_url_params.update(dict(spotlight_id=spotlight_id))
 
             dataset.source.tiles = self._format_urls(


### PR DESCRIPTION
added a check to insert `EUPorts` as the spotlightId in the Source URL for the nightlights-viirs dataset when querying `du` or `gh`