### PR TITLE
Added `euports` into dataset source tile for `nightlights-viirs dataset, for spotlights `du` and `gh`

### DIFF
--- a/covid_api/db/static/datasets/__init__.py
+++ b/covid_api/db/static/datasets/__init__.py
@@ -169,7 +169,7 @@ class DatasetManager(object):
             # spotlight id (if a spotlight was requested)
             format_url_params = dict(api_url=api_url)
             if spotlight_id:
-                if k == "nightlights-hd" and spotlight_id in ["du", "gh"]:
+                if k == "nightlights-viirs" and spotlight_id in ["du", "gh"]:
                     spotlight_id = "EUPorts"
                 format_url_params.update(dict(spotlight_id=spotlight_id))
 


### PR DESCRIPTION
I had incorrectly inserted `EUPorts` into the Nighlights-hd dataset source tile url, instead of the Nighlights-viirs dataset. This PR changes that