### PR TITLE
Bugfix: mask out `nodata` value in timelapse endpoint

### DIFF
--- a/covid_api/api/api_v1/endpoints/timelapse.py
+++ b/covid_api/api/api_v1/endpoints/timelapse.py
@@ -37,7 +37,8 @@ def _get_mean_median(query, url, dataset):
         mean, median = get_zonal_stat(query.geojson, url)
         return dict(mean=mean, median=median)
 
-    except Exception:
+    except Exception as e:
+        print(e)
         raise HTTPException(
             status_code=400,
             detail=(

--- a/covid_api/api/api_v1/endpoints/timelapse.py
+++ b/covid_api/api/api_v1/endpoints/timelapse.py
@@ -37,8 +37,7 @@ def _get_mean_median(query, url, dataset):
         mean, median = get_zonal_stat(query.geojson, url)
         return dict(mean=mean, median=median)
 
-    except Exception as e:
-        print(e)
+    except Exception:
         raise HTTPException(
             status_code=400,
             detail=(

--- a/covid_api/api/utils.py
+++ b/covid_api/api/utils.py
@@ -238,16 +238,14 @@ def get_zonal_stat(geojson: Feature, raster: str) -> Tuple[float, float]:
         window = bounds_window(geom.bounds, src.transform)
         # store our window information & read
         window_affine = src.window_transform(window)
-        data = src.read(window=window)
+        data = src.read(window=window, masked=True)
 
         # calculate the coverage of pixels for weighting
         pctcover = rasterize_pctcover(geom, atrans=window_affine, shape=data.shape[1:])
 
-        masked_data = np.ma.masked_values(data[0], src.nodatavals[0])
-
         return (
-            np.ma.average(masked_data, weights=pctcover),
-            np.ma.median(masked_data),
+            np.ma.average(data[0], weights=pctcover),
+            np.ma.median(data[0]),
         )
 
 

--- a/covid_api/api/utils.py
+++ b/covid_api/api/utils.py
@@ -247,7 +247,6 @@ def get_zonal_stat(geojson: Feature, raster: str) -> Tuple[float, float]:
 
         return (
             np.ma.average(masked_data, weights=pctcover),
-            # np.nanmedian(data),
             np.ma.median(masked_data),
         )
 

--- a/covid_api/models/timelapse.py
+++ b/covid_api/models/timelapse.py
@@ -25,9 +25,13 @@ class PolygonFeature(Feature):
 class TimelapseValue(BaseModel):
     """"Timelapse values model."""
 
+    # TODO: there should be a check that either
+    # mean and median are not-null OR error is not-null,
+    # but NOT BOTH.
     date: Optional[str]
-    mean: float
-    median: float
+    mean: Optional[float]
+    median: Optional[float]
+    error: Optional[str]
 
 
 class TimelapseRequest(BaseModel):


### PR DESCRIPTION
Also added an optional `error` field in timelapse endpoint response model so that they API can respond with partial data (if tiles aren't available for the full date range for example)
