### PR TITLE
Sets rescale values for the CO2 (mean) dataset to [0.0003908,0.0004225]

### DIFF
--- a/covid_api/db/static/datasets/co2.json
+++ b/covid_api/db/static/datasets/co2.json
@@ -8,7 +8,7 @@
     "source": {
         "type": "raster",
         "tiles": [
-            "{api_url}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/xco2-mean/xco2_16day_mean.{date}.tif&resampling_method=bilinear&bidx=1&rescale=0.000408%2C0.000419&color_map=rdylbu_r&color_formula=gamma r {gamma}"
+            "{api_url}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/xco2-mean/xco2_16day_mean.{date}.tif&resampling_method=bilinear&bidx=1&rescale=0.0003908%2C0.0004225&color_map=rdylbu_r&color_formula=gamma r {gamma}"
         ]
     },
     "exclusive_with": [
@@ -48,8 +48,8 @@
     },
     "legend": {
         "type": "gradient-adjustable",
-        "min": "< 408 ppm",
-        "max": "> 419 ppm",
+        "min": "< 391 ppm",
+        "max": "> 423 ppm",
         "stops": [
             "#313695",
             "#588cbf",


### PR DESCRIPTION
CO2 (mean) measurements are very small, on the other order of ~400 parts per million. With values steadily increasing by about 2.5 parts per million each year, the rescalling factor used when displaying the tiles needs to be updated since more recent values are falling outside of the range of the rescaling factor. There are 2 options: 
1. Set rescaling factors to yearly max/min: this will make the seasonal variations most obvious, but will mask the increase in CO2 particles in the atmosphere year to year. 
2. Set rescaling factors to dataset max/min: this will "wash out" the seasonal variations slightly but will make the year to year increase visible.

The CO2 scientists has indicated a clear preference for yearly min/max values. For the time being, we have no functionality to change the rescaling factors at any level lower than the dataset level, so option `1.` will not be possible for time being.

This PR implements options 2, and we be sure to include this feature request in our discovery efforts for the next iteration of the dashboard/API.