### PR TITLE
Updates FB population density dataset rescale values after reprocessing dataset

### DIFF
--- a/covid_api/db/static/datasets/fb-population-density.json
+++ b/covid_api/db/static/datasets/fb-population-density.json
@@ -6,7 +6,7 @@
     "source": {
         "type": "raster",
         "tiles": [
-            "{api_url}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/dataforgood-fb-population-density/cog.tif&rescale=0,69&resampling_method=nearest&color_map=ylorrd"
+            "{api_url}/{z}/{x}/{y}@1x?url=s3://covid-eo-data/dataforgood-fb-population-density/hrsl_general_latest_global_cog.tif&rescale=0.0%2C72.0&resampling_method=nearest&color_map=ylorrd"
         ]
     },
     "paint": {
@@ -36,7 +36,7 @@
     "legend": {
         "type": "gradient",
         "min": "0 people/30m²",
-        "max": "69 people/30m²",
+        "max": "72 people/30m²",
         "stops": [
             "#FFEFCB",
             "#FBA54A",


### PR DESCRIPTION
New dataset min/max values are: [0,72] (people per 30m^2). 

Some notes: 
- There are some data issues in northern and eastern Kenya, along the South Sudan/Ethiopia/Somalia borders. See screenshot below:
![image](https://user-images.githubusercontent.com/11858457/138952215-50fe83d8-7e61-409d-bb02-3b23c0fc50ab.png)

- There are still linear artifacts appearing in the overviews of cities with linear road infrastructure (most notable in south-wester US cities, but also Massachusetts and London. See screenshots below: 
![image](https://user-images.githubusercontent.com/11858457/138952343-bca9aa1c-a3cd-407d-9613-9c6efc58c4cc.png)
![image](https://user-images.githubusercontent.com/11858457/138952487-b027d309-c3ef-436d-af85-1c13115be234.png)

This is likely due to the use of bilinear or cubic resampling when calculating overviews - the latest version of GDAL offers the ability to calculate `sum` overviews which I've been told would work very well for this dataset