### PR TITLE
Update planet URL from PSScene3Band to PSScene

### DIFF
--- a/covid_api/api/utils.py
+++ b/covid_api/api/utils.py
@@ -725,7 +725,7 @@ def planet_mosaic_tile(scenes, x, y, z):
     mosaic_tile = np.zeros((4, 256, 256), dtype=np.uint8)
     for scene in scenes:
         api_num = math.floor(random.random() * 3) + 1
-        url = f"https://tiles{api_num}.planet.com/data/v1/PSScene3Band/{scene}/{z}/{x}/{y}.png?api_key={PLANET_API_KEY}"
+        url = f"https://tiles{api_num}.planet.com/data/v1/PSScene/{scene}/{z}/{x}/{y}.png?api_key={PLANET_API_KEY}"
         r = requests.get(url)
         with MemoryFile(BytesIO(r.content)) as memfile:
             with memfile.open() as src:


### PR DESCRIPTION
We started getting 401s with no solid evidence about why. Apparently, a URL needed to be updated.
Before:
<img width="909" alt="image" src="https://github.com/NASA-IMPACT/covid-api/assets/1977405/17fe5cce-ba85-4adf-b02d-4f6dc7ecdef3">

After:
<img width="1086" alt="image" src="https://github.com/NASA-IMPACT/covid-api/assets/1977405/15a9ff8e-9bf4-4f5a-90c4-3647ddcb68c1">
